### PR TITLE
Improve linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-- '5.0'
+- '6.9'
 - 'stable'
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 notifications:
   slack:
     secure: gbnDpemhgdH0Lw9DngVRR29No27NkX0Cv/di42uJ43JnMFV8xWemBcS4oi2rI9cc7ZZ8JCRHMG4MnopBfQ9j+OEO/IGLGacKs4p0JnSKq72lB5J2GrbtDjpL15Uvz9/JuCM6HdB6OddYtEKAKiw1NsU4ykXmy8gWBLnvP1s4fvooBQyAuEJnDb6Sf6FgRofvARM2KbDL4kiol0ikTEx/qYi6v6KUPy7V2sykbU/0Tq9LZpgKUuBepBc9d0VoWrDxaAGpv+K/YSPfSXxSsFp4iqfXt0ge+9LaNeszm7I0mI8Rh7I3FVpdxdr/Nam3ZQOU1551PPOUbqN6yI3tCK2yGR8lVunl1EFqO2wyA+cGXn2NTxZl4J/IDEcG12VoJU6JJMvpEY3vAHZnRBRawlnXvaadQ3xPDGTocJGs1ovcmQpM31sYobdNy9m15gWPNcJJMAYIdQRxTyRY/vSzRZL+Rcnyjtr1aq8r4s7xnCF2Bznxayi2nupDUi2DxsXeywabKr0/L/GmtzFBqWJTbwlvB3NaV//Gc9mrgPyvobl+rGYt10MfUd0EYiFAnyhnvxNbL/s2c7R7Y4d2/K8GWFOrRPujvgQYB5DO1/wikJNaI4EeOY+pJVV7DQQrBjwIg4xTxLhwgq02ih6z8g0Wm/FOd4N3QXJvbOZw/KtpJ3n41hc=

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "scripts": {
     "build": "ember build",
-    "lint": "npm run lint-js && npm run lint-md",
-    "lint-js": "eslint *.js addon app blueprints config tests",
-    "lint-md": "remark *.md",
+    "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && ember test"
   },
@@ -35,18 +33,15 @@
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-mocha": "0.13.1",
+    "ember-cli-mocha": "0.13.2",
     "ember-cli-test-loader": "^1.1.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.1.1",
     "ember-load-initializers": "0.6.3",
     "ember-resolver": "^2.1.1",
-    "eslint": "^3.13.1",
-    "eslint-config-frost-standard": "^5.3.2",
+    "ember-test-utils": "^1.10.3",
     "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
     "seamless-immutable": "6.3.0"
   },
   "keywords": [


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.
