### PR TITLE
Monkey patch default export to play nicer with Ember

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -59,10 +59,23 @@ function patchArraySlice (array) {
  * @param {Object} object - object to get immutable copy of
  * @returns {Object} immutable object
  */
-export default function (object) {
+function immutable (object) {
   if (!Immutable.isImmutable(object)) {
     keepEmbersHandsOff(object)
   }
 
   return Immutable.call(this, ...arguments)
 }
+
+// Make sure to map methods from Immutable onto default export
+
+;[
+  'from',
+  'isImmutable',
+  'ImmutableError'
+]
+  .forEach((key) => {
+    immutable[key] = Immutable[key]
+  })
+
+export default immutable

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,68 @@
-export {Immutable as default} from './seamless-immutable'
+import {Immutable} from './seamless-immutable'
+
+const {isArray} = Array
+
+const NON_ENUMERABLE_KEY = '__defineNonEnumerable'
+
+/**
+ * No-op function that does nothing
+ */
+function noop () {}
+
+/**
+ * Add non enumerable property to object which keeps Ember from trying to
+ * add other properties to the object.
+ * @param {Object} object - object to add non enumerable property to
+ */
+function addNonEnumerableProperty (object) {
+  if (object[NON_ENUMERABLE_KEY]) return
+  object[NON_ENUMERABLE_KEY] = noop
+}
+
+/**
+ * Tell Ember to keep it's hands off an object and all nested objects
+ * @param {Object} object - object to tell Ember to keep its hands off of
+ */
+function keepEmbersHandsOff (object) {
+  if (isArray(object)) {
+    patchArraySlice(object)
+  } else {
+    addNonEnumerableProperty(object)
+  }
+
+  Object.keys(object).forEach((key) => {
+    if (key === NON_ENUMERABLE_KEY) return
+
+    if (object[key] instanceof Object) {
+      keepEmbersHandsOff(object[key])
+    }
+  })
+}
+
+/**
+ * Patch slice method on Object to make sure Ember keeps it's hands off of
+ * items added to the array.
+ * @param {Array} array - array to patch slice method of
+ */
+function patchArraySlice (array) {
+  const originalFn = array.slice
+
+  array.slice = function slice () {
+    const result = originalFn.call(this, ...arguments)
+    addNonEnumerableProperty(result)
+    return result
+  }
+}
+
+/**
+ * Thin wrapper around Immutable that makes it play nice with Ember
+ * @param {Object} object - object to get immutable copy of
+ * @returns {Object} immutable object
+ */
+export default function (object) {
+  if (!Immutable.isImmutable(object)) {
+    keepEmbersHandsOff(object)
+  }
+
+  return Immutable.call(this, ...arguments)
+}

--- a/tests/unit/utils/seamless-immutable-exports-test.js
+++ b/tests/unit/utils/seamless-immutable-exports-test.js
@@ -2,6 +2,8 @@ import {expect} from 'chai'
 import {describe, it} from 'mocha'
 import immutable from 'seamless-immutable'
 
+const NON_ENUMERABLE_KEY = '__defineNonEnumerable'
+
 describe('seamless-immutable', function () {
   it('immutable is a single module that has been exported', function () {
     expect(typeof immutable).to.equal('function')
@@ -17,4 +19,8 @@ describe('seamless-immutable', function () {
         expect(typeof immutable[key]).to.equal('function')
       })
     })
+
+  it('does not let Ember try to mutate immutable objects', function () {
+    expect(typeof immutable({baz: 'test'})[NON_ENUMERABLE_KEY]).to.equal('function')
+  })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** default export to monkey patch immutable objects in a way that keeps Ember from trying to add properties to them, which results in an exception. This allows immutable objects to be directly referenced in templates and computed properties.