### PR TITLE
Make __defineNonEnumerable non-enumerable

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,88 +1,699 @@
-import {Immutable} from './seamless-immutable'
+/* eslint-disable complexity */
+
+import config from 'ember-get-config'
+const {environment} = config
 
 const {isArray} = Array
-const {defineProperty} = Object
 
-const NON_ENUMERABLE_KEY = '__defineNonEnumerable'
+const {
+  assign,
+  defineProperty,
+  freeze,
+  getOwnPropertyDescriptor
+} = Object
 
-/**
- * No-op function that does nothing
- */
+// https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L21
+var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')
+var REACT_ELEMENT_TYPE_FALLBACK = 0xeac7
+
+function addPropertyTo (target, methodName, value) {
+  defineProperty(target, methodName, {
+    enumerable: false,
+    configurable: false,
+    writable: false,
+    value: value
+  })
+}
+
+function banProperty (target, methodName) {
+  addPropertyTo(target, methodName, function () {
+    throw new ImmutableError('The ' + methodName +
+      ' method cannot be invoked on an Immutable data structure.')
+  })
+}
+
+var immutabilityTag = '__immutable_invariants_hold'
+var defineNonEnumerableTag = '__defineNonEnumerable'
+
+function addImmutabilityTag (target) {
+  addPropertyTo(target, immutabilityTag, true)
+}
+
 function noop () {}
 
-/**
- * Add non enumerable property to object which keeps Ember from trying to
- * add other properties to the object.
- * @param {Object} object - object to add non enumerable property to
- */
-function addNonEnumerableProperty (object) {
-  if (object[NON_ENUMERABLE_KEY]) return
-
-  defineProperty(object, NON_ENUMERABLE_KEY, {
-    configurable: false,
-    enumerable: false,
-    value: noop,
-    writable: false
-  })
+function addDefineNonEnumerableTag (target) {
+  addPropertyTo(target, defineNonEnumerableTag, noop)
 }
 
-/**
- * Tell Ember to keep it's hands off an object and all nested objects
- * @param {Object} object - object to tell Ember to keep its hands off of
- */
-function keepEmbersHandsOff (object) {
-  if (isArray(object)) {
-    patchArraySlice(object)
+function isImmutable (target) {
+  if (typeof target === 'object') {
+    return target === null || Boolean(
+      getOwnPropertyDescriptor(target, immutabilityTag)
+    )
   } else {
-    addNonEnumerableProperty(object)
+    // In JavaScript, only objects are even potentially mutable.
+    // strings, numbers, null, and undefined are all naturally immutable.
+    return true
+  }
+}
+
+function isEqual (a, b) {
+  // Avoid false positives due to (NaN !== NaN) evaluating to true
+  /* eslint-disable no-self-compare */
+  return (a === b || (a !== a && b !== b))
+  /* eslint-enable no-self-compare */
+}
+
+function isMergableObject (target) {
+  return target !== null && typeof target === 'object' && !(isArray(target)) && !(target instanceof Date)
+}
+
+var mutatingObjectMethods = [
+  'setPrototypeOf'
+]
+
+var nonMutatingObjectMethods = [
+  'keys'
+]
+
+var mutatingArrayMethods = mutatingObjectMethods.concat([
+  'push', 'pop', 'sort', 'splice', 'shift', 'unshift', 'reverse'
+])
+
+var nonMutatingArrayMethods = nonMutatingObjectMethods.concat([
+  'map', 'filter', 'slice', 'concat', 'reduce', 'reduceRight'
+])
+
+var mutatingDateMethods = mutatingObjectMethods.concat([
+  'setDate', 'setFullYear', 'setHours', 'setMilliseconds', 'setMinutes', 'setMonth', 'setSeconds',
+  'setTime', 'setUTCDate', 'setUTCFullYear', 'setUTCHours', 'setUTCMilliseconds', 'setUTCMinutes',
+  'setUTCMonth', 'setUTCSeconds', 'setYear'
+])
+
+function ImmutableError (message) {
+  var err = new Error(message)
+  // TODO: Consider `Object.setPrototypeOf(err, ImmutableError);`
+  /* eslint-disable no-proto */
+  err.__proto__ = ImmutableError
+  /* eslint-enable no-proto */
+
+  return err
+}
+
+ImmutableError.prototype = Error.prototype
+
+function makeImmutable (obj, bannedMethods) {
+  // Tag it so we can quickly tell it's immutable later.
+  addImmutabilityTag(obj)
+
+  // Tag it so Ember won't try to mutate it
+  addDefineNonEnumerableTag(obj)
+
+  if (environment !== 'production') {
+    // Make all mutating methods throw exceptions.
+    for (var index in bannedMethods) {
+      if (bannedMethods.hasOwnProperty(index)) {
+        banProperty(obj, bannedMethods[index])
+      }
+    }
+
+    // Freeze it and return it.
+    freeze(obj)
   }
 
-  Object.keys(object).forEach((key) => {
-    if (key === NON_ENUMERABLE_KEY) return
+  return obj
+}
 
-    if (object[key] instanceof Object) {
-      keepEmbersHandsOff(object[key])
-    }
+function makeMethodReturnImmutable (obj, methodName) {
+  var currentMethod = obj[methodName]
+
+  addPropertyTo(obj, methodName, function () {
+    return Immutable(currentMethod.apply(obj, arguments))
   })
 }
 
-/**
- * Patch slice method on Object to make sure Ember keeps it's hands off of
- * items added to the array.
- * @param {Array} array - array to patch slice method of
- */
-function patchArraySlice (array) {
-  const originalFn = array.slice
+function arraySet (idx, value, config) {
+  var deep = config && config.deep
 
-  array.slice = function slice () {
-    const result = originalFn.call(this, ...arguments)
-    addNonEnumerableProperty(result)
-    return result
+  if (idx in this) {
+    if (deep && this[idx] !== value && isMergableObject(value) && isMergableObject(this[idx])) {
+      value = this[idx].merge(value, {deep: true, mode: 'replace'})
+    }
+    if (isEqual(this[idx], value)) {
+      return this
+    }
+  }
+
+  var mutable = asMutableArray.call(this)
+  mutable[idx] = Immutable(value)
+  return makeImmutableArray(mutable)
+}
+
+var immutableEmptyArray = Immutable([])
+
+function arraySetIn (pth, value, config) {
+  var head = pth[0]
+
+  if (pth.length === 1) {
+    return arraySet.call(this, head, value, config)
+  } else {
+    var tail = pth.slice(1)
+    var thisHead = this[head]
+    var newValue
+
+    if (typeof thisHead === 'object' && thisHead !== null && typeof thisHead.setIn === 'function') {
+      // Might (validly) be object or array
+      newValue = thisHead.setIn(tail, value)
+    } else {
+      var nextHead = tail[0]
+      // If the next path part is a number, then we are setting into an array, else an object.
+      if (nextHead !== '' && isFinite(nextHead)) {
+        newValue = arraySetIn.call(immutableEmptyArray, tail, value)
+      } else {
+        newValue = objectSetIn.call(immutableEmptyObject, tail, value)
+      }
+    }
+
+    if (head in this && thisHead === newValue) {
+      return this
+    }
+
+    var mutable = asMutableArray.call(this)
+    mutable[head] = newValue
+    return makeImmutableArray(mutable)
   }
 }
 
+function makeImmutableArray (array) {
+  // Don't change their implementations, but wrap these functions to make sure
+  // they always return an immutable value.
+  for (var index in nonMutatingArrayMethods) {
+    if (nonMutatingArrayMethods.hasOwnProperty(index)) {
+      var methodName = nonMutatingArrayMethods[index]
+      makeMethodReturnImmutable(array, methodName)
+    }
+  }
+
+  addPropertyTo(array, 'flatMap', flatMap)
+  addPropertyTo(array, 'asObject', asObject)
+  addPropertyTo(array, 'asMutable', asMutableArray)
+  addPropertyTo(array, 'set', arraySet)
+  addPropertyTo(array, 'setIn', arraySetIn)
+  addPropertyTo(array, 'update', update)
+  addPropertyTo(array, 'updateIn', updateIn)
+
+  for (var i = 0, length = array.length; i < length; i++) {
+    array[i] = Immutable(array[i])
+  }
+
+  return makeImmutable(array, mutatingArrayMethods)
+}
+
+function makeImmutableDate (date) {
+  addPropertyTo(date, 'asMutable', asMutableDate)
+
+  return makeImmutable(date, mutatingDateMethods)
+}
+
+function asMutableDate () {
+  return new Date(this.getTime())
+}
+
 /**
- * Thin wrapper around Immutable that makes it play nice with Ember
- * @param {Object} object - object to get immutable copy of
+ * Effectively performs a map() over the elements in the array, using the
+ * provided iterator, except that whenever the iterator returns an array, that
+ * array's elements are added to the final result instead of the array itself.
+ *
+ * @param {Function} iterator - The iterator function that will be invoked on each element in the array. It will receive three arguments: the current value, the current index, and the current object.
+ * @returns {Array} immutable array
+ */
+function flatMap (iterator) {
+  // Calling .flatMap() with no arguments is a no-op. Don't bother cloning.
+  if (arguments.length === 0) {
+    return this
+  }
+
+  var result = []
+  var length = this.length
+  var index
+
+  for (index = 0; index < length; index++) {
+    var iteratorResult = iterator(this[index], index, this)
+
+    if (isArray(iteratorResult)) {
+      // Concatenate Array results into the return value we're building up.
+      result.push.apply(result, iteratorResult)
+    } else {
+      // Handle non-Array results the same way map() does.
+      result.push(iteratorResult)
+    }
+  }
+
+  return makeImmutableArray(result)
+}
+
+/**
+ * Returns an Immutable copy of the object without the given keys included.
+ *
+ * @param {Array<String>} remove - A list of strings representing the keys to exclude in the return value. Instead of providing a single array, this method can also be called by passing multiple strings as separate arguments.
  * @returns {Object} immutable object
  */
-function immutable (object) {
-  if (!Immutable.isImmutable(object)) {
-    keepEmbersHandsOff(object)
+function without (remove) {
+  // Calling .without() with no arguments is a no-op. Don't bother cloning.
+  if (typeof remove === 'undefined' && arguments.length === 0) {
+    return this
   }
 
-  return Immutable.call(this, ...arguments)
+  if (typeof remove !== 'function') {
+    // If we weren't given an array, use the arguments list.
+    var keysToRemoveArray = (isArray(remove)) ? remove.slice() : Array.prototype.slice.call(arguments)
+
+    // Convert numeric keys to strings since that's how they'll
+    // come from the enumeration of the object.
+    keysToRemoveArray.forEach(function (el, idx, arr) {
+      if (typeof el === 'number') {
+        arr[idx] = el.toString()
+      }
+    })
+
+    remove = function (val, key) {
+      return keysToRemoveArray.indexOf(key) !== -1
+    }
+  }
+
+  var result = this.instantiateEmptyObject()
+
+  for (var key in this) {
+    if (this.hasOwnProperty(key) && remove(this[key], key) === false) {
+      result[key] = this[key]
+    }
+  }
+
+  return makeImmutableObject(result,
+    {instantiateEmptyObject: this.instantiateEmptyObject})
 }
 
-// Make sure to map methods from Immutable onto default export
+function asMutableArray (opts) {
+  var result = []
+  var i
+  var length
 
-;[
-  'from',
-  'isImmutable',
-  'ImmutableError'
-]
-  .forEach((key) => {
-    immutable[key] = Immutable[key]
-  })
+  if (opts && opts.deep) {
+    for (i = 0, length = this.length; i < length; i++) {
+      result.push(asDeepMutable(this[i]))
+    }
+  } else {
+    for (i = 0, length = this.length; i < length; i++) {
+      result.push(this[i])
+    }
+  }
 
-export default immutable
+  return result
+}
+
+/**
+ * Effectively performs a [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) over the elements in the array, expecting that the iterator function
+ * will return an array of two elements - the first representing a key, the other
+ * a value. Then returns an Immutable Object constructed of those keys and values.
+ *
+ * @param {Function} iterator - A function which should return an array of two elements - the first representing the desired key, the other the desired value.
+ * @returns {Object} immutable object
+ */
+function asObject (iterator) {
+  // If no iterator was provided, assume the identity function
+  // (suggesting this array is already a list of key/value pairs.)
+  if (typeof iterator !== 'function') {
+    iterator = function (value) {
+      return value
+    }
+  }
+
+  var result = {}
+  var length = this.length
+  var index
+
+  for (index = 0; index < length; index++) {
+    var pair = iterator(this[index], index, this)
+    var key = pair[0]
+    var value = pair[1]
+
+    result[key] = value
+  }
+
+  return makeImmutableObject(result)
+}
+
+function asDeepMutable (obj) {
+  if (
+    (!obj) ||
+    (typeof obj !== 'object') ||
+    (!getOwnPropertyDescriptor(obj, immutabilityTag)) ||
+    (obj instanceof Date)
+  ) {
+    return obj
+  }
+
+  return obj.asMutable({deep: true})
+}
+
+function quickCopy (src, dest) {
+  for (var key in src) {
+    if (getOwnPropertyDescriptor(src, key)) {
+      dest[key] = src[key]
+    }
+  }
+
+  return dest
+}
+
+/**
+ * Returns an Immutable Object containing the properties and values of both
+ * this object and the provided object, prioritizing the provided object's
+ * values whenever the same key is present in both objects.
+ *
+ * @param {object} other - The other object to merge. Multiple objects can be passed as an array. In such a case, the later an object appears in that list, the higher its priority.
+ * @param {object} config - Optional config object that contains settings. Supported settings are: {deep: true} for deep merge and {merger: mergerFunc} where mergerFunc is a function
+ *                          that takes a property from both objects. If anything is returned it overrides the normal merge behaviour.
+ * @returns {Object} immutable object
+ */
+function merge (other, config) {
+  // Calling .merge() with no arguments is a no-op. Don't bother cloning.
+  if (arguments.length === 0) {
+    return this
+  }
+
+  if (other === null || (typeof other !== 'object')) {
+    throw new TypeError('Immutable#merge can only be invoked with objects or arrays, not ' + JSON.stringify(other))
+  }
+
+  var receivedArray = (isArray(other))
+  var deep = config && config.deep
+  var mode = config && config.mode || 'merge'
+  var merger = config && config.merger
+  var result
+
+  // Use the given key to extract a value from the given object, then place
+  // that value in the result object under the same key. If that resulted
+  // in a change from this object's value at that key, set anyChanges = true.
+  function addToResult (currentObj, otherObj, key) {
+    var immutableValue = Immutable(otherObj[key])
+    var mergerResult = merger && merger(currentObj[key], immutableValue, config)
+    var currentValue = currentObj[key]
+
+    if (
+      (result !== undefined) ||
+      (mergerResult !== undefined) ||
+      (!currentObj.hasOwnProperty(key)) ||
+      !isEqual(immutableValue, currentValue)
+    ) {
+      var newValue
+
+      if (mergerResult) {
+        newValue = mergerResult
+      } else if (deep && isMergableObject(currentValue) && isMergableObject(immutableValue)) {
+        newValue = currentValue.merge(immutableValue, config)
+      } else {
+        newValue = immutableValue
+      }
+
+      if (!isEqual(currentValue, newValue) || !currentObj.hasOwnProperty(key)) {
+        if (result === undefined) {
+          // Make a shallow clone of the current object.
+          result = quickCopy(currentObj, currentObj.instantiateEmptyObject())
+        }
+
+        result[key] = newValue
+      }
+    }
+  }
+
+  function clearDroppedKeys (currentObj, otherObj) {
+    for (var key in currentObj) {
+      if (!otherObj.hasOwnProperty(key)) {
+        if (result === undefined) {
+          // Make a shallow clone of the current object.
+          result = quickCopy(currentObj, currentObj.instantiateEmptyObject())
+        }
+        delete result[key]
+      }
+    }
+  }
+
+  var key
+
+  // Achieve prioritization by overriding previous values that get in the way.
+  if (!receivedArray) {
+    // The most common use case: just merge one object into the existing one.
+    for (key in other) {
+      if (getOwnPropertyDescriptor(other, key)) {
+        addToResult(this, other, key)
+      }
+    }
+    if (mode === 'replace') {
+      clearDroppedKeys(this, other)
+    }
+  } else {
+    // We also accept an Array
+    for (var index = 0, length = other.length; index < length; index++) {
+      var otherFromArray = other[index]
+
+      for (key in otherFromArray) {
+        if (otherFromArray.hasOwnProperty(key)) {
+          addToResult(result !== undefined ? result : this, otherFromArray, key)
+        }
+      }
+    }
+  }
+
+  if (result === undefined) {
+    return this
+  } else {
+    return makeImmutableObject(result,
+      {instantiateEmptyObject: this.instantiateEmptyObject})
+  }
+}
+
+function objectReplace (value, config) {
+  var deep = config && config.deep
+
+  // Calling .replace() with no arguments is a no-op. Don't bother cloning.
+  if (arguments.length === 0) {
+    return this
+  }
+
+  if (value === null || typeof value !== 'object') {
+    throw new TypeError('Immutable#replace can only be invoked with objects or arrays, not ' + JSON.stringify(value))
+  }
+
+  return this.merge(value, {deep: deep, mode: 'replace'})
+}
+
+var immutableEmptyObject = Immutable({})
+
+function objectSetIn (path, value, config) {
+  var head = path[0]
+
+  if (path.length === 1) {
+    return objectSet.call(this, head, value, config)
+  }
+
+  var tail = path.slice(1)
+  var newValue
+  var thisHead = this[head]
+
+  if (
+    this.hasOwnProperty(head) &&
+    typeof thisHead === 'object' &&
+    thisHead !== null &&
+    typeof thisHead.setIn === 'function'
+  ) {
+    // Might (validly) be object or array
+    newValue = thisHead.setIn(tail, value)
+  } else {
+    newValue = objectSetIn.call(immutableEmptyObject, tail, value)
+  }
+
+  if (this.hasOwnProperty(head) && thisHead === newValue) {
+    return this
+  }
+
+  var mutable = quickCopy(this, this.instantiateEmptyObject())
+  mutable[head] = newValue
+  return makeImmutableObject(mutable, this)
+}
+
+function objectSet (property, value, config) {
+  var deep = config && config.deep
+
+  if (this.hasOwnProperty(property)) {
+    if (deep && this[property] !== value && isMergableObject(value) && isMergableObject(this[property])) {
+      value = this[property].merge(value, {deep: true, mode: 'replace'})
+    }
+    if (isEqual(this[property], value)) {
+      return this
+    }
+  }
+
+  var mutable = quickCopy(this, this.instantiateEmptyObject())
+  mutable[property] = Immutable(value)
+  return makeImmutableObject(mutable, this)
+}
+
+function update (property, updater) {
+  var restArgs = Array.prototype.slice.call(arguments, 2)
+  var initialVal = this[property]
+  return this.set(property, updater.apply(initialVal, [initialVal].concat(restArgs)))
+}
+
+function getInPath (obj, path) {
+  for (var i = 0, l = path.length; obj != null && i < l; i++) {
+    obj = obj[path[i]]
+  }
+
+  /* eslint-disable eqeqeq */
+  return (i && i == l) ? obj : undefined
+  /* eslint-enable eqeqeq */
+}
+
+function updateIn (path, updater) {
+  var restArgs = Array.prototype.slice.call(arguments, 2)
+  var initialVal = getInPath(this, path)
+
+  return this.setIn(path, updater.apply(initialVal, [initialVal].concat(restArgs)))
+}
+
+function asMutableObject (opts) {
+  var result = this.instantiateEmptyObject()
+  var key
+
+  if (opts && opts.deep) {
+    for (key in this) {
+      if (this.hasOwnProperty(key)) {
+        result[key] = asDeepMutable(this[key])
+      }
+    }
+  } else {
+    for (key in this) {
+      if (this.hasOwnProperty(key)) {
+        result[key] = this[key]
+      }
+    }
+  }
+
+  return result
+}
+
+// Creates plain object to be used for cloning
+function instantiatePlainObject () {
+  return {}
+}
+
+// Finalizes an object with immutable methods, freezes it, and returns it.
+function makeImmutableObject (obj, options) {
+  var instantiateEmptyObject = (
+    (options && options.instantiateEmptyObject) ? options.instantiateEmptyObject : instantiatePlainObject
+  )
+
+  addPropertyTo(obj, 'merge', merge)
+  addPropertyTo(obj, 'replace', objectReplace)
+  addPropertyTo(obj, 'without', without)
+  addPropertyTo(obj, 'asMutable', asMutableObject)
+  addPropertyTo(obj, 'instantiateEmptyObject', instantiateEmptyObject)
+  addPropertyTo(obj, 'set', objectSet)
+  addPropertyTo(obj, 'setIn', objectSetIn)
+  addPropertyTo(obj, 'update', update)
+  addPropertyTo(obj, 'updateIn', updateIn)
+
+  return makeImmutable(obj, mutatingObjectMethods)
+}
+
+// Returns true if object is a valid react element
+// https://github.com/facebook/react/blob/v15.0.1/src/isomorphic/classic/element/ReactElement.js#L326
+function isReactElement (obj) {
+  return typeof obj === 'object' &&
+         obj !== null &&
+         (obj.$$typeof === REACT_ELEMENT_TYPE_FALLBACK || obj.$$typeof === REACT_ELEMENT_TYPE)
+}
+
+function Immutable (obj, options, stackRemaining) {
+  if (isImmutable(obj) || isReactElement(obj)) {
+    return obj
+  } else if (isArray(obj)) {
+    return makeImmutableArray(obj.slice())
+  } else if (obj instanceof Date) {
+    return makeImmutableDate(new Date(obj.getTime()))
+  } else {
+    // Don't freeze the object we were given; make a clone and use that.
+    var prototype = options && options.prototype
+    var instantiateEmptyObject =
+      (!prototype || prototype === Object.prototype) ? instantiatePlainObject : function () {
+        return Object.create(prototype)
+      }
+    var clone = instantiateEmptyObject()
+
+    if (environment !== 'production') {
+      if (stackRemaining == null) {
+        stackRemaining = 64
+      }
+      if (stackRemaining <= 0) {
+        throw new ImmutableError('Attempt to construct Immutable from a deeply nested object was detected.' +
+          ' Have you tried to wrap an object with circular references (e.g. React element)?' +
+          ' See https://github.com/rtfeldman/seamless-immutable/wiki/Deeply-nested-object-was-detected for details.')
+      }
+      stackRemaining -= 1
+    }
+
+    for (var key in obj) {
+      if (getOwnPropertyDescriptor(obj, key)) {
+        clone[key] = Immutable(obj[key], undefined, stackRemaining)
+      }
+    }
+
+    return makeImmutableObject(clone,
+      {instantiateEmptyObject: instantiateEmptyObject})
+  }
+}
+
+// Wrapper to allow the use of object methods as static methods of Immutable.
+function toStatic (fn) {
+  return function () {
+    var args = [].slice.call(arguments)
+    var self = args.shift()
+    return fn.apply(self, args)
+  }
+}
+
+// Wrapper to allow the use of object methods as static methods of Immutable.
+// with the additional condition of choosing which function to call depending
+// if argument is an array or an object.
+function toStaticObjectOrArray (fnObject, fnArray) {
+  return function () {
+    var args = [].slice.call(arguments)
+    var self = args.shift()
+    if (isArray(self)) {
+      return fnArray.apply(self, args)
+    } else {
+      return fnObject.apply(self, args)
+    }
+  }
+}
+
+assign(Immutable, {
+  asMutable: toStaticObjectOrArray(asMutableObject, asMutableArray),
+  asObject: toStatic(asObject),
+  flatMap: toStatic(flatMap),
+  from: Immutable,
+  ImmutableError: ImmutableError,
+  isImmutable: isImmutable,
+  merge: toStatic(merge),
+  replace: toStatic(objectReplace),
+  set: toStaticObjectOrArray(objectSet, arraySet),
+  setIn: toStaticObjectOrArray(objectSetIn, arraySetIn),
+  update: toStatic(update),
+  updateIn: toStatic(updateIn),
+  without: toStatic(without)
+})
+
+freeze(Immutable)
+
+export default Immutable

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,7 @@
 import {Immutable} from './seamless-immutable'
 
 const {isArray} = Array
+const {defineProperty} = Object
 
 const NON_ENUMERABLE_KEY = '__defineNonEnumerable'
 
@@ -16,7 +17,13 @@ function noop () {}
  */
 function addNonEnumerableProperty (object) {
   if (object[NON_ENUMERABLE_KEY]) return
-  object[NON_ENUMERABLE_KEY] = noop
+
+  defineProperty(object, NON_ENUMERABLE_KEY, {
+    configurable: false,
+    enumerable: false,
+    value: noop,
+    writable: false
+  })
 }
 
 /**

--- a/blueprints/ember-seamless-immutable-shim/index.js
+++ b/blueprints/ember-seamless-immutable-shim/index.js
@@ -1,15 +1,10 @@
 module.exports = {
   afterInstall: function () {
-    return this.addPackagesToProject([
-      {name: 'seamless-immutable', target: '6.3.0'}
-    ])
-      .then(() => {
-        return this.addAddonsToProject({
-          packages: [
-            {name: 'ember-get-config', target: '0.2.1'}
-          ]
-        })
-      })
+    return this.addAddonsToProject({
+      packages: [
+        {name: 'ember-get-config', target: '0.2.1'}
+      ]
+    })
   },
 
   normalizeEntityName: function () {

--- a/blueprints/ember-seamless-immutable-shim/index.js
+++ b/blueprints/ember-seamless-immutable-shim/index.js
@@ -3,6 +3,13 @@ module.exports = {
     return this.addPackagesToProject([
       {name: 'seamless-immutable', target: '6.3.0'}
     ])
+      .then(() => {
+        return this.addAddonsToProject({
+          packages: [
+            {name: 'ember-get-config', target: '0.2.1'}
+          ]
+        })
+      })
   },
 
   normalizeEntityName: function () {

--- a/index.js
+++ b/index.js
@@ -1,55 +1,5 @@
 'use strict'
 
-const mergeTrees = require('broccoli-merge-trees')
-const path = require('path')
-const replace = require('broccoli-replace')
-
 module.exports = {
-  name: 'seamless-immutable',
-  /*
-     This method climbs up the hierarchy of addons
-     up to the host application.
-     This prevents previous addons (prior to `this.import`, ca 2.7.0)
-     to break at importing assets when they are used nested in other addons.
-   */
-  _findHost: function () {
-    var current = this
-    var app
-
-    // Keep iterating upward until we don't have a grandparent.
-    // Has to do this grandparent check because at some point we hit the project.
-    do {
-      app = current.app || app
-    } while (current && current.parent && current.parent.parent && (current = current.parent))
-
-    return app
-  },
-
-  treeForAddon (tree) {
-    var app = this._findHost()
-    const seamlessImmutablePath = path.dirname(require.resolve('seamless-immutable/src/seamless-immutable.js'))
-    let seamlessImmutableTree = this.treeGenerator(seamlessImmutablePath)
-
-    seamlessImmutableTree = replace(seamlessImmutableTree, {
-      files: [
-        '**/*.js'
-      ],
-      patterns: [
-        {
-          match: /process\.env\.NODE_ENV/g,
-          replacement: `"${app.env}"`
-        }
-      ]
-    })
-
-    if (!tree) {
-      return this._super.treeForAddon.call(this, seamlessImmutableTree)
-    }
-
-    const trees = mergeTrees([seamlessImmutableTree, tree], {
-      overwrite: true
-    })
-
-    return this._super.treeForAddon.call(this, trees)
-  }
+  name: 'seamless-immutable'
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.1.1",
+    "ember-get-config": "0.2.1",
     "ember-load-initializers": "0.6.3",
     "ember-resolver": "^2.1.1",
     "ember-test-utils": "^1.10.3",
@@ -52,8 +53,6 @@
     "seamless-immutable"
   ],
   "dependencies": {
-    "broccoli-merge-trees": "^1.0.0",
-    "broccoli-replace": "^0.12.0",
     "ember-cli-babel": "^5.1.9",
     "ember-cli-htmlbars": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "ember-load-initializers": "0.6.3",
     "ember-resolver": "^2.1.1",
     "ember-test-utils": "^1.10.3",
-    "loader.js": "^4.1.0",
-    "seamless-immutable": "6.3.0"
+    "loader.js": "^4.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug where `__defineNonEnumerable` was showing up on immutable objects as an enumerable property.
